### PR TITLE
in-tree ksmbd

### DIFF
--- a/package/kernel/ksmbd/Makefile
+++ b/package/kernel/ksmbd/Makefile
@@ -25,6 +25,7 @@ define KernelPackage/fs-ksmbd-external
 	PROVIDES:=kmod-fs-ksmbd
 	CONFLICTS:=kmod-fs-ksmbd-intree
 	DEPENDS:= \
+		@LINUX_5_10 \
 		+kmod-nls-base \
 		+kmod-nls-utf8 \
 		+kmod-crypto-md4 \

--- a/package/kernel/ksmbd/Makefile
+++ b/package/kernel/ksmbd/Makefile
@@ -22,7 +22,6 @@ define KernelPackage/fs-ksmbd-external
 	TITLE:=SMB kernel server support
 	URL:=https://github.com/cifsd-team/cifsd
 	FILES:=$(PKG_BUILD_DIR)/ksmbd.ko
-	PROVIDES:=kmod-fs-ksmbd
 	CONFLICTS:=kmod-fs-ksmbd-intree
 	DEPENDS:= \
 		@LINUX_5_10 \

--- a/package/kernel/ksmbd/Makefile
+++ b/package/kernel/ksmbd/Makefile
@@ -17,11 +17,13 @@ include $(INCLUDE_DIR)/package.mk
 TAR_OPTIONS+= --strip-components 1
 TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
 
-define KernelPackage/fs-ksmbd
+define KernelPackage/fs-ksmbd-external
 	SUBMENU:=Filesystems
 	TITLE:=SMB kernel server support
 	URL:=https://github.com/cifsd-team/cifsd
 	FILES:=$(PKG_BUILD_DIR)/ksmbd.ko
+	PROVIDES:=kmod-fs-ksmbd
+	CONFLICTS:=kmod-fs-ksmbd-intree
 	DEPENDS:= \
 		+kmod-nls-base \
 		+kmod-nls-utf8 \
@@ -43,15 +45,15 @@ endef
 # The last two DEPENDS are hacks in order to get CONFIG_ASN1 and CONFIG_OID_REGISTRY
 # which it seems can't be selected independently. Some bug in either base or upstream.
 
-define KernelPackage/fs-ksmbd/description
+define KernelPackage/fs-ksmbd-external/description
   Ksmbd is an In-kernel SMBv(1)2/3 fileserver.
   It's an implementation of the SMB protocol in kernel space for sharing files and IPC services over network.
 endef
 
-define KernelPackage/fs-ksmbd/config
+define KernelPackage/fs-ksmbd-external/config
 config KSMBD_SMB_INSECURE_SERVER
 	bool "Support for insecure SMB1/CIFS and SMB2.0 protocols"
-	depends on PACKAGE_kmod-fs-ksmbd
+	depends on PACKAGE_kmod-fs-ksmbd-external
 	help
 		This enables deprecated insecure protocols dialects: SMB1/CIFS and SMB2.0.
 	default y
@@ -70,4 +72,4 @@ define Build/Compile
 	modules
 endef
 
-$(eval $(call KernelPackage,fs-ksmbd))
+$(eval $(call KernelPackage,fs-ksmbd-external))

--- a/package/kernel/ksmbd/patches/02-ksmbd-smb1-fix-build-error-on-kernel-6-1.patch
+++ b/package/kernel/ksmbd/patches/02-ksmbd-smb1-fix-build-error-on-kernel-6-1.patch
@@ -1,0 +1,30 @@
+From 82477bc639c38a71784fe155f691f8e9f482fe50 Mon Sep 17 00:00:00 2001
+From: Chukun Pan <amadeus@jmu.edu.cn>
+Date: Thu, 15 Dec 2022 15:10:09 +0800
+Subject: [PATCH] ksmbd: smb1: fix build error on kernel 6.1
+
+This fixes the following error:
+smb1pdu.c:5964:50: error: passing argument 2 of 'set_ctx_actor'
+from incompatible pointer type [-Werror=incompatible-pointer-types]
+5964 | set_ctx_actor(&dir_fp->readdir_data.ctx, ksmbd_fill_dirent);
+
+Signed-off-by: Chukun Pan <amadeus@jmu.edu.cn>
+Signed-off-by: Namjae Jeon <linkinjeon@kernel.org>
+---
+ smb1pdu.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/smb1pdu.c
++++ b/smb1pdu.c
+@@ -5851,7 +5851,11 @@ static int smb_populate_readdir_entry(st
+  *
+  * Return:	0 on success, otherwise -EINVAL
+  */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
++static bool ksmbd_fill_dirent(struct dir_context *ctx, const char *name, int namlen,
++#else
+ static int ksmbd_fill_dirent(struct dir_context *ctx, const char *name, int namlen,
++#endif
+ 		loff_t offset, u64 ino, unsigned int d_type)
+ {
+ 	struct ksmbd_readdir_data *buf =

--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -348,6 +348,27 @@ endef
 
 $(eval $(call KernelPackage,fs-jfs))
 
+
+define KernelPackage/fs-ksmbd
+  SUBMENU:=$(FS_MENU)
+  TITLE:=SMB kernel server support
+  DEPENDS:=+kmod-asn1-decoder +kmod-oid-registry @!LINUX_5_10
+  KCONFIG:= \
+	CONFIG_SMB_SERVER=y \
+	CONFIG_SMB_SERVER_SMBDIRECT=n \
+	CONFIG_SMB_SERVER_CHECK_CAP_NET_ADMIN=n \
+	CONFIG_SMB_SERVER_KERBEROS5=n
+  FILES:=$(LINUX_DIR)/fs/ksmbd/ksmbd.ko
+  AUTOLOAD:=$(call AutoLoad,41,ksmbd)
+endef
+
+define KernelPackage/fs-ksmbd/description
+ Kernel module for SMB kernel server support
+endef
+
+$(eval $(call KernelPackage,fs-ksmbd))
+
+
 define KernelPackage/fs-minix
   SUBMENU:=$(FS_MENU)
   TITLE:=Minix filesystem support

--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -353,9 +353,24 @@ define KernelPackage/fs-ksmbd-intree
   SUBMENU:=$(FS_MENU)
   TITLE:=SMB kernel server support
   PROVIDES:=kmod-fs-ksmbd
-  DEPENDS:=+kmod-asn1-decoder +kmod-oid-registry @!LINUX_5_10
+  DEPENDS:= \
+	    +kmod-fs-smbfs-common \
+	    +kmod-nls-base \
+	    +kmod-nls-utf8 \
+	    +kmod-crypto-md5 \
+	    +kmod-crypto-hmac \
+	    +kmod-crypto-ecb \
+	    +kmod-crypto-des \
+	    +kmod-crypto-sha256 \
+	    +kmod-crypto-cmac \
+	    +kmod-crypto-sha512 \
+	    +kmod-crypto-aead \
+	    +kmod-crypto-ccm \
+	    +kmod-crypto-gcm \
+	    +kmod-asn1-decoder \
+	    +kmod-oid-registry
   KCONFIG:= \
-	CONFIG_SMB_SERVER=y \
+	CONFIG_SMB_SERVER \
 	CONFIG_SMB_SERVER_SMBDIRECT=n \
 	CONFIG_SMB_SERVER_CHECK_CAP_NET_ADMIN=n \
 	CONFIG_SMB_SERVER_KERBEROS5=n

--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -83,21 +83,37 @@ endef
 $(eval $(call KernelPackage,fs-btrfs))
 
 
+define KernelPackage/fs-smbfs-common
+  SUBMENU:=$(FS_MENU)
+  TITLE:=SMBFS common dependencies support
+  HIDDEN:=1
+  DEPENDS+=@!LINUX_5_10
+  KCONFIG:=CONFIG_SMBFS_COMMON
+  FILES:= \
+	$(LINUX_DIR)/fs/smbfs_common/cifs_arc4.ko \
+	$(LINUX_DIR)/fs/smbfs_common/cifs_md4.ko
+endef
+
+define KernelPackage/fs-smbfs-common/description
+ Kernel module dependency for CIFS or SMB_SERVER support
+endef
+
+$(eval $(call KernelPackage,fs-smbfs-common))
+
+
 define KernelPackage/fs-cifs
   SUBMENU:=$(FS_MENU)
   TITLE:=CIFS support
   KCONFIG:= \
-	CONFIG_SMBFS_COMMON@ge5.15 \
 	CONFIG_CIFS \
 	CONFIG_CIFS_DFS_UPCALL=n \
 	CONFIG_CIFS_UPCALL=n
   FILES:= \
-	$(LINUX_DIR)/fs/smbfs_common/cifs_arc4.ko@ge5.15 \
-	$(LINUX_DIR)/fs/smbfs_common/cifs_md4.ko@ge5.15 \
 	$(LINUX_DIR)/fs/cifs/cifs.ko
   AUTOLOAD:=$(call AutoLoad,30,cifs)
   $(call AddDepends/nls)
   DEPENDS+= \
+    +LINUX_5_15:kmod-fs-smbfs-common \
     +LINUX_5_10:kmod-crypto-md4\
     +kmod-crypto-md5 \
     +kmod-crypto-sha256 \

--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -348,11 +348,21 @@ endef
 
 $(eval $(call KernelPackage,fs-jfs))
 
+define KernelPackage/fs-ksmbd
+  SUBMENU:=$(FS_MENU)
+  TITLE:=SMB kernel server virtual package
+  HIDDEN:=1
+  DEPENDS:= \
+	    +LINUX_5_10:kmod-fs-ksmbd-external \
+	    +(LINUX_5_15||LINUX_6_1):kmod-fs-ksmbd-intree
+endef
+
+$(eval $(call KernelPackage,fs-ksmbd))
+
 
 define KernelPackage/fs-ksmbd-intree
   SUBMENU:=$(FS_MENU)
   TITLE:=SMB kernel server support
-  PROVIDES:=kmod-fs-ksmbd
   DEPENDS:= \
 	    +kmod-fs-smbfs-common \
 	    +kmod-nls-base \

--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -349,9 +349,10 @@ endef
 $(eval $(call KernelPackage,fs-jfs))
 
 
-define KernelPackage/fs-ksmbd
+define KernelPackage/fs-ksmbd-intree
   SUBMENU:=$(FS_MENU)
   TITLE:=SMB kernel server support
+  PROVIDES:=kmod-fs-ksmbd
   DEPENDS:=+kmod-asn1-decoder +kmod-oid-registry @!LINUX_5_10
   KCONFIG:= \
 	CONFIG_SMB_SERVER=y \
@@ -362,11 +363,11 @@ define KernelPackage/fs-ksmbd
   AUTOLOAD:=$(call AutoLoad,41,ksmbd)
 endef
 
-define KernelPackage/fs-ksmbd/description
+define KernelPackage/fs-ksmbd-intree/description
  Kernel module for SMB kernel server support
 endef
 
-$(eval $(call KernelPackage,fs-ksmbd))
+$(eval $(call KernelPackage,fs-ksmbd-intree))
 
 
 define KernelPackage/fs-minix


### PR DESCRIPTION
Intention is to allow installation of one `kmod-fs-ksmbd` provider

Seemed to build okay on a 6.1 `ALL_KMODS` test, but only compile tested

```
find . -iname '*ksmbd*ko'
./packages/ipkg-mipsel_24kc/kmod-fs-ksmbd-intree/lib/modules/6.1.0/ksmbd.ko
./packages/.pkgdir/kmod-fs-ksmbd-intree/lib/modules/6.1.0/ksmbd.ko
./ksmbd-3.4.6/ksmbd.ko
./ksmbd-3.4.6/ipkg-mipsel_24kc/kmod-fs-ksmbd-external/lib/modules/6.1.0/ksmbd.ko
./ksmbd-3.4.6/.pkgdir/kmod-fs-ksmbd-external/lib/modules/6.1.0/ksmbd.ko
./linux-6.1/fs/ksmbd/ksmbd.ko
[john@john linux-ramips_mt7621]$ find . -iname '*ksmbd*ko'
./packages/ipkg-mipsel_24kc/kmod-fs-ksmbd-intree/lib/modules/6.1.0/ksmbd.ko
./packages/.pkgdir/kmod-fs-ksmbd-intree/lib/modules/6.1.0/ksmbd.ko
./ksmbd-3.4.6/ipkg-mipsel_24kc/kmod-fs-ksmbd-external/lib/modules/6.1.0/ksmbd.ko
./ksmbd-3.4.6/ksmbd.ko
./ksmbd-3.4.6/.pkgdir/kmod-fs-ksmbd-external/lib/modules/6.1.0/ksmbd.ko
./linux-6.1/fs/ksmbd/ksmbd.ko
```

would squash all intree ksmbd commits