### PR TITLE
ramips: mt7621: mikrotik: initram use lzma loader

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1647,6 +1647,9 @@ define Device/MikroTik
   DEVICE_PACKAGES := kmod-usb3 -uboot-envtools
   KERNEL_NAME := vmlinuz
   KERNEL := kernel-bin | append-dtb-elf
+  LOADER_TYPE := elf
+  KERNEL_INITRAMFS_NAME := vmlinux-initramfs
+  KERNEL_INITRAMFS := $(KERNEL_DTB) | loader-kernel
   IMAGE/sysupgrade.bin := append-kernel | kernel2minor -s 1024 | \
 	pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | \
 	append-metadata


### PR DESCRIPTION
Use OpenWrt's lzma loader for initramfs image
Due to mips kernel self extractor inability to relocate, and RouterBoot on 760igs refusing to netboot an ELF with:
Entry point address:               0x80b91000
or greater: 0x80b81000 and below okay.

Note that this is only a bootloader ELF entry point limitation, a 50MiB Linux + initramfs vmlinux will boot fine on 760igs.

With this lzma loader, netboot will occasionally freeze after decompressing the kernel, but before starting vmlinux. It was considered that an occasional netboot freeze was simpler to workaround than an image that refuses to boot unless minimized.
